### PR TITLE
HybridRecommender: "min" and "max" aggregation; "fill the gaps" recommender

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides a research infrastructure to test and develop
     rule-based algorithms.
 Classification/ACM: G.4, H.2.8
 Depends: R (>= 3.5.0), Matrix, arules, proxy (>= 0.4-26), registry
-Imports: methods, utils, stats, irlba, recosystem
+Imports: methods, utils, stats, irlba, recosystem, matrixStats
 Suggests: testthat
 BugReports: https://github.com/mhahsler/recommenderlab/issues
 URL: https://github.com/mhahsler/recommenderlab

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -18,6 +18,7 @@ importFrom("Matrix", "rowSums", "colSums", "rowMeans", "colMeans",
   "summary", "drop0", "rBind")
 ## get just methods
 importMethodsFrom("Matrix", "image", "t", "crossprod", "tcrossprod", "which")
+importFrom("matrixStats", "colMaxs", "colMins")
 
 ## get generics and methods
 importFrom("arules", "predict", "nitems", "sample", "LIST",

--- a/R/RECOM_AR.R
+++ b/R/RECOM_AR.R
@@ -66,17 +66,21 @@ BIN_AR <- function(data, parameter = NULL) {
 
     m <- is.subset(lhs(model$rule_base), newdata@data)
     reclist <- list()
+    ratings <- list()
     for(i in 1:nrow(newdata)) {
-      recom <- unique(unlist(
-        LIST(rhs(sort(model$rule_base[m[,i]], by = sort_measure)),
-          decode=FALSE)))
-
-      reclist[[i]] <- if(!is.null(recom)) recom else integer(0)
+      ars <- sort(model$rule_base[m[,i]], by = sort_measure)
+      ar_rhs <- unlist(LIST(rhs(ars), decode=FALSE))
+      ar_qualities <- quality(ars)[[sort_measure]]
+      ar_duplicates <- duplicated(ar_rhs)
+      recom_item <- ar_rhs[!ar_duplicates]
+      recom_qual <- ar_qualities[!ar_duplicates]
+      
+      reclist[[i]] <- if(!is.null(recom_item)) recom_item else integer(0)
+      ratings[[i]] <- if(!is.null(recom_qual)) recom_qual else integer(0)
     }
 
     names(reclist) <- rownames(newdata)
     # create ratings that reflect the order of the topNlist
-    ratings <- lapply(reclist, FUN = function(x) seq(1, 0, along.with = x))
     topN <- new("topNList", items = reclist, ratings = ratings,
       itemLabels = colnames(newdata), n = ncol(newdata))
 


### PR DESCRIPTION
Extending the HybridRecommender for aggregation of ratings over individual recommenders using *max* or *min* is, I think, a useful feature per se; for example, one can create a "most defensive" recommender using `aggregation_type="min"`.

However, more importantly, one can use it to create a "fill the gaps" recommender: Suppose a recommender creates incomplete top-*N* lists; this regularly happens with RECOM_AR for high *N*, for example. The new version can be used to fill the free slots using another recommender, such as RECOM_POPULAR. Just build a hybrid of the two, pick `aggregation_type="max"` and give AR a weight of `1/(1+AR_quality)` (where `AR_quality` is the minimum quality - such as confidence, support, etc. - from AR mining used to sort the ARs for prediction). This will rescale the ratings of both recommenders such that those of the former are always larger than those of the latter (which is possible with RECOM_AR in this version because the sorting quality is now used as rating), and thus all recommendations of the former - if available - are preferred; however, *within* the recommenders, the orderings of ratings are preserved.