### PR TITLE
Update RECOM_AR.R

### DIFF
--- a/R/RECOM_AR.R
+++ b/R/RECOM_AR.R
@@ -33,7 +33,7 @@ BIN_AR <- function(data, parameter = NULL) {
     cxs = quality(rule_base)$confidence * quality(rule_base)$support)
 
   if(!p$sort_measure %in% names(quality(rule_base))) quality(rule_base) <-
-    cbind(quality(rule_base), interestMeasure(rule_base, method = p$sort_measure,
+    cbind(quality(rule_base), interestMeasure(rule_base, measure = p$sort_measure,
       transactions = data))
 
   ## sort rule_base


### PR DESCRIPTION
Change the parameter from `method` to `measure` for the interestMeasure method in AR Recommender. This is to do a quick patch for #63.