### PR TITLE
Patch for #65

### DIFF
--- a/R/RECOM_AR.R
+++ b/R/RECOM_AR.R
@@ -32,9 +32,12 @@ BIN_AR <- function(data, parameter = NULL) {
   if(p$sort_measure == "cxs") quality(rule_base) <- cbind(quality(rule_base),
     cxs = quality(rule_base)$confidence * quality(rule_base)$support)
 
-  if(!p$sort_measure %in% names(quality(rule_base))) quality(rule_base) <-
-    cbind(quality(rule_base), interestMeasure(rule_base, measure = p$sort_measure,
-      transactions = data))
+  if(!p$sort_measure %in% names(quality(rule_base))) {
+      quality(rule_base) <- cbind(
+        quality(rule_base), 
+        setNames(as.data.frame(interestMeasure(rule_base, measure = c(p$sort_measure), transactions = data)), p$sort_measure)
+    )
+  }
 
   ## sort rule_base
   rule_base <- sort(rule_base, by = p$sort_measure, decreasing=p$sort_decreasing)

--- a/R/RECOM_AR.R
+++ b/R/RECOM_AR.R
@@ -33,7 +33,7 @@ BIN_AR <- function(data, parameter = NULL) {
     cxs = quality(rule_base)$confidence * quality(rule_base)$support)
 
   if(!p$sort_measure %in% names(quality(rule_base))) quality(rule_base) <-
-    cbind(quality(rule_base), interestMeasure(rule_base, method = p$sort_measure,
+    cbind(quality(rule_base), interestMeasure(rule_base, measure = p$sort_measure,
       transactions = data))
 
   ## sort rule_base


### PR DESCRIPTION
When using `interestMeasure` to calculate only 1 measure, i.e. `hyperConfidence`, it will return a vector. Hence, `cbind` will take the entire function call as the column name, instead of the actual measure name.

So, I convert the single measure into a data.frame, and use `setNames` to give it a column name before `cbind`. 

This fixes issue #65 
